### PR TITLE
Samuelstroschein/inl-24-use-local-files-for-translations

### DIFF
--- a/packages/js/src/inlang.ts
+++ b/packages/js/src/inlang.ts
@@ -1,5 +1,5 @@
 import { InlangTextApi } from './inlangTextApi'
-import type { InlangProjectConfig, Locale } from './types'
+import type { InlangProjectConfig, Locale, Translations } from './types'
 
 /**
  * Use for fine-grained control of inlang by specifying the config.
@@ -55,10 +55,7 @@ export class Inlang {
     constructor(args: {
         projectConfig: InlangProjectConfig
         locale: Locale
-        translations: Record<
-            string,
-            Record<string, string | undefined> | undefined
-        >
+        translations: Translations
         textApi?: typeof InlangTextApi
     }) {
         this.#projectConfig = args.projectConfig
@@ -110,7 +107,7 @@ export class Inlang {
         // the translation local -> post missing translation
         if (
             this.#locale !== this.#projectConfig.developmentLocale &&
-            this.#translations[this.#locale]?.[trimmed] === undefined
+            this.#translations[trimmed]?.[this.#locale] === undefined
         ) {
             // the key does not exist, thus post as missing translation
             this.#postMissingTranslation(trimmed)
@@ -118,7 +115,7 @@ export class Inlang {
         // in any case return the TextApi which will fallback to the input
         // but the user will see text.
         return new this.#textApi(trimmed, {
-            translation: this.#translations[this.#locale]?.[trimmed],
+            translation: this.#translations[trimmed]?.[this.#locale],
             locale: this.#locale,
         })
             .variables(args?.vars)

--- a/packages/js/src/types.ts
+++ b/packages/js/src/types.ts
@@ -5,6 +5,24 @@
 
 export type SingleTranslation = string
 
+/**
+ * @example The key is the default language of the project.
+ * {
+ *   "Hello World": {
+ *     "de": "Hallo Welt"
+ *     "fr": "Bonjour le monde"
+ *   }
+ *   ...
+ * }
+ */
+export type Translations = {
+    [key: string]:
+        | {
+              [locale: string]: string | undefined
+          }
+        | undefined
+}
+
 export type InlangProjectConfig = {
     projectId: string
     developmentLocale: Locale

--- a/packages/js/test/inlang.test.ts
+++ b/packages/js/test/inlang.test.ts
@@ -1,10 +1,11 @@
 import { Inlang } from '../src/inlang'
+import { Translations } from '../src/types'
 
-const mockDeTranslations = {
-    'About this app': 'Über diese App',
-    'You have {num} todos': 'Du hast {num} Todos',
-    'You have {num} {color} todos': 'Du hast {num} {color} Todos',
-    green: 'grün',
+const mockTranslations: Translations = {
+    'About this app': { de: 'Über diese App' },
+    'You have {num} todos': { de: 'Du hast {num} Todos' },
+    'You have {num} {color} todos': { de: 'Du hast {num} {color} Todos' },
+    green: { de: 'grün' },
 }
 
 const inlang = new Inlang({
@@ -14,9 +15,7 @@ const inlang = new Inlang({
         locales: ['de'],
     },
     locale: 'de',
-    translations: {
-        de: mockDeTranslations,
-    },
+    translations: mockTranslations,
 })
 
 test('Translation does not exist. Expect to return fallback', () => {
@@ -28,7 +27,7 @@ test('Translation does not exist. Expect to return fallback', () => {
 test('Existing translation. Expect translation', () => {
     const text = 'About this app'
     const result = inlang.translate(text)
-    expect(result).toEqual(mockDeTranslations[text])
+    expect(result).toEqual(mockTranslations[text]?.['de'])
 })
 
 // test('Interpolation but variable is undefined -> throw an error ', () => {


### PR DESCRIPTION
Inlang now exports an inlang constructor to whom the translations are passed. In the future (end of the week hehe), a `t` function can be exported which initializes an inlang object based on a config file in the repo. Whereas the config file is auto generated by the dashboard.